### PR TITLE
add station autocomplete functionality using EFA RapidJSON API

### DIFF
--- a/custom_components/vrr/autocomplete.py
+++ b/custom_components/vrr/autocomplete.py
@@ -1,0 +1,204 @@
+"""Station autocomplete functionality for VRR/KVV integration."""
+import logging
+import aiohttp
+import asyncio
+from typing import List, Dict, Any, Optional
+from urllib.parse import quote
+
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import (
+    API_STOPFINDER_URL_VRR,
+    API_STOPFINDER_URL_KVV,
+    PROVIDER_VRR,
+    PROVIDER_KVV,
+    MIN_SEARCH_LENGTH,
+    MAX_SUGGESTIONS,
+    AUTOCOMPLETE_TIMEOUT
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+class StationAutocomplete:
+    """Handle station autocomplete requests for VRR and KVV."""
+
+    def __init__(self, hass):
+        """Initialize the autocomplete handler."""
+        self._hass = hass
+        self._session = async_get_clientsession(hass)
+
+    async def search_stations(
+            self,
+            provider: str,
+            search_term: str
+    ) -> List[Dict[str, Any]]:
+        """Search for stations matching the search term."""
+
+        if len(search_term.strip()) < MIN_SEARCH_LENGTH:
+            return []
+
+        try:
+            if provider == PROVIDER_VRR:
+                return await self._search_vrr_stations(search_term)
+            elif provider == PROVIDER_KVV:
+                return await self._search_kvv_stations(search_term)
+            else:
+                _LOGGER.error("Unknown provider: %s", provider)
+                return []
+
+        except Exception as e:
+            _LOGGER.error("Error searching stations for %s: %s", provider, e)
+            return []
+
+    async def _search_vrr_stations(self, search_term: str) -> List[Dict[str, Any]]:
+        """Search VRR stations."""
+        url = API_STOPFINDER_URL_VRR
+
+        params = {
+            "outputFormat": "rapidJSON",
+            "type_sf": "any",
+            "name_sf": search_term,
+            "stateless": "1",
+            "locationServerActive": "1",
+            "useHouseNumberList": "0"
+        }
+
+        return await self._make_request(url, params, self._parse_vrr_response)
+
+    async def _search_kvv_stations(self, search_term: str) -> List[Dict[str, Any]]:
+        """Search KVV stations."""
+        url = API_STOPFINDER_URL_KVV
+
+        params = {
+            "outputFormat": "rapidJSON",
+            "type_sf": "any",
+            "name_sf": search_term,
+            "stateless": "1",
+            "locationServerActive": "1"
+        }
+
+        return await self._make_request(url, params, self._parse_kvv_response)
+
+    async def _make_request(
+            self,
+            url: str,
+            params: Dict[str, str],
+            parser_func
+    ) -> List[Dict[str, Any]]:
+        """Make the API request and parse response."""
+
+        # Build query string manually to ensure proper encoding
+        query_parts = []
+        for key, value in params.items():
+            query_parts.append(f"{key}={quote(str(value))}")
+        query_string = "&".join(query_parts)
+
+        full_url = f"{url}?{query_string}"
+
+        headers = {
+            "User-Agent": "Mozilla/5.0 (compatible; HomeAssistant VRR/KVV Integration)",
+            "Accept": "application/json",
+        }
+
+        try:
+            async with self._session.get(
+                    full_url,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=AUTOCOMPLETE_TIMEOUT)
+            ) as response:
+
+                if response.status == 200:
+                    data = await response.json()
+                    return parser_func(data)
+                else:
+                    _LOGGER.warning("API returned status %s", response.status)
+                    return []
+
+        except asyncio.TimeoutError:
+            _LOGGER.warning("Request timeout for station search")
+            return []
+        except Exception as e:
+            _LOGGER.error("Request failed: %s", e)
+            return []
+
+    def _parse_vrr_response(self, data: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Parse VRR API response for station suggestions."""
+        suggestions = []
+
+        locations = data.get("locations", [])
+        for location in locations[:MAX_SUGGESTIONS]:
+            if location.get("type") == "stop":
+                station = self._extract_station_info_vrr(location)
+                if station:
+                    suggestions.append(station)
+
+        return suggestions
+
+    def _parse_kvv_response(self, data: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Parse KVV API response for station suggestions."""
+        suggestions = []
+
+        locations = data.get("locations", [])
+        for location in locations[:MAX_SUGGESTIONS]:
+            if location.get("type") == "stop":
+                station = self._extract_station_info_kvv(location)
+                if station:
+                    suggestions.append(station)
+
+        return suggestions
+
+    def _extract_station_info_vrr(self, location: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Extract station information from VRR location data."""
+        try:
+            # VRR format: usually has place and name separated
+            name = location.get("name", "")
+            place = location.get("place", "")
+            station_id = location.get("id", "")
+
+            # Sometimes the name includes the place, let's handle both cases
+            if place and place.lower() not in name.lower():
+                display_name = f"{place} - {name}"
+            else:
+                display_name = name
+
+            return {
+                "id": station_id,
+                "name": name,
+                "place": place,
+                "display_name": display_name,
+                "coordinates": {
+                    "lat": location.get("coord", [None, None])[1],
+                    "lon": location.get("coord", [None, None])[0]
+                }
+            }
+        except Exception as e:
+            _LOGGER.debug("Error extracting VRR station info: %s", e)
+            return None
+
+    def _extract_station_info_kvv(self, location: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Extract station information from KVV location data."""
+        try:
+            # KVV format might be slightly different
+            name = location.get("name", "")
+            place = location.get("place", "")
+            station_id = location.get("id", "")
+
+            # Handle KVV naming format
+            if place and place.lower() not in name.lower():
+                display_name = f"{place} - {name}"
+            else:
+                display_name = name
+
+            return {
+                "id": station_id,
+                "name": name,
+                "place": place,
+                "display_name": display_name,
+                "coordinates": {
+                    "lat": location.get("coord", [None, None])[1],
+                    "lon": location.get("coord", [None, None])[0]
+                }
+            }
+        except Exception as e:
+            _LOGGER.debug("Error extracting KVV station info: %s", e)
+            return None

--- a/custom_components/vrr/config_flow.py
+++ b/custom_components/vrr/config_flow.py
@@ -1,60 +1,78 @@
 import voluptuous as vol
+import logging
 from homeassistant import config_entries
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.data_entry_flow import FlowResult
+from typing import Any, Dict, Optional
 
 from .const import (
-    DOMAIN, 
-    DEFAULT_PLACE, 
-    DEFAULT_NAME, 
+    DOMAIN,
+    DEFAULT_PLACE,
+    DEFAULT_NAME,
     DEFAULT_DEPARTURES,
     DEFAULT_SCAN_INTERVAL,
-    CONF_PROVIDER,  # NEU
+    CONF_PROVIDER,
     CONF_STATION_ID,
     CONF_DEPARTURES,
     CONF_TRANSPORTATION_TYPES,
     CONF_SCAN_INTERVAL,
+    CONF_SEARCH_TERM,
+    CONF_SELECTED_STATION,
     TRANSPORTATION_TYPES,
-    PROVIDERS
+    PROVIDERS,
+    MIN_SEARCH_LENGTH
 )
+from .autocomplete import StationAutocomplete
+
+_LOGGER = logging.getLogger(__name__)
 
 class VRRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for VRR integration."""
 
     VERSION = 1
 
+    def __init__(self):
+        """Initialize config flow."""
+        self._provider = "vrr"
+        self._autocomplete = None
+        self._station_suggestions = []
+        self._user_input = {}
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
-        
-        if user_input is not None:
-            # Validate station ID or place/name
-            station_id = user_input.get(CONF_STATION_ID, "").strip()
-            place_dm = user_input.get("place_dm", "").strip()
-            name_dm = user_input.get("name_dm", "").strip()
-            
-            if not station_id and (not place_dm or not name_dm):
-                errors["base"] = "missing_location"
-            else:
-                # Create unique ID
-                provider = user_input.get(CONF_PROVIDER, "vrr")
-                if station_id:
-                    unique_id = f"{provider}_{station_id}"
-                    title = f"{provider.upper()} Station {station_id}"
-                else:
-                    unique_id = f"{provider}_{place_dm}_{name_dm}".lower().replace(" ", "_")
-                    title = f"{provider.upper()} {place_dm} - {name_dm}"
-                
-                await self.async_set_unique_id(unique_id)
-                self._abort_if_unique_id_configured()
-                
-                return self.async_create_entry(
-                    title=title,
-                    data=user_input,
-                )
 
+        if user_input is not None:
+            self._user_input.update(user_input)
+            self._provider = user_input.get(CONF_PROVIDER, "vrr")
+
+            # Check if user wants to use autocomplete
+            search_term = user_input.get(CONF_SEARCH_TERM, "").strip()
+            selected_station = user_input.get(CONF_SELECTED_STATION)
+
+            if search_term and len(search_term) >= MIN_SEARCH_LENGTH:
+                # User entered search term, show suggestions
+                return await self.async_step_station_search(user_input)
+            elif selected_station:
+                # User selected a station from suggestions
+                return await self._create_entry_from_selection(selected_station)
+            else:
+                # Validate manual input
+                station_id = user_input.get(CONF_STATION_ID, "").strip()
+                place_dm = user_input.get("place_dm", "").strip()
+                name_dm = user_input.get("name_dm", "").strip()
+
+                if not station_id and (not place_dm or not name_dm):
+                    errors["base"] = "missing_location"
+                else:
+                    # Create entry with manual input
+                    return await self._create_entry_from_manual_input(user_input)
+
+        # Show initial form
         schema = vol.Schema({
-            vol.Required(CONF_PROVIDER, default="vrr"): vol.In(PROVIDERS),
+            vol.Required(CONF_PROVIDER, default=self._provider): vol.In(PROVIDERS),
+            vol.Optional(CONF_SEARCH_TERM, default=""): str,
             vol.Optional(CONF_STATION_ID, default=""): str,
             vol.Optional("place_dm", default=DEFAULT_PLACE): str,
             vol.Optional("name_dm", default=DEFAULT_NAME): str,
@@ -64,15 +82,151 @@ class VRRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         })
 
         return self.async_show_form(
-            step_id="user", 
-            data_schema=schema, 
+            step_id="user",
+            data_schema=schema,
             errors=errors,
             description_placeholders={
-                "station_id_help": "Optional: Use VRR Station ID instead of place/name",
+                "search_help": f"Enter at least {MIN_SEARCH_LENGTH} characters to search for stations",
+                "station_id_help": "Optional: Use specific Station ID instead of place/name",
                 "place_help": "City or area name (e.g., Düsseldorf)",
                 "name_help": "Station or stop name (e.g., Hauptbahnhof)"
             }
         )
+
+    async def async_step_station_search(self, user_input=None):
+        """Handle station search with autocomplete."""
+        errors = {}
+
+        if user_input is not None:
+            selected_station = user_input.get(CONF_SELECTED_STATION)
+            new_search_term = user_input.get(CONF_SEARCH_TERM, "").strip()
+
+            if selected_station:
+                # User selected a station
+                return await self._create_entry_from_selection(selected_station)
+            elif new_search_term != self._user_input.get(CONF_SEARCH_TERM, ""):
+                # User changed search term
+                self._user_input[CONF_SEARCH_TERM] = new_search_term
+                if len(new_search_term) >= MIN_SEARCH_LENGTH:
+                    await self._update_station_suggestions(new_search_term)
+                else:
+                    self._station_suggestions = []
+        else:
+            # Initial search
+            search_term = self._user_input.get(CONF_SEARCH_TERM, "")
+            if len(search_term) >= MIN_SEARCH_LENGTH:
+                await self._update_station_suggestions(search_term)
+
+        # Create dynamic schema with station suggestions
+        schema_dict = {
+            vol.Required(CONF_PROVIDER, default=self._provider): vol.In(PROVIDERS),
+            vol.Optional(CONF_SEARCH_TERM, default=self._user_input.get(CONF_SEARCH_TERM, "")): str,
+        }
+
+        # Add station selection if we have suggestions
+        if self._station_suggestions:
+            station_options = {}
+            for station in self._station_suggestions:
+                key = f"{station['place']}|{station['name']}|{station['id']}"
+                station_options[key] = station['display_name']
+
+            schema_dict[vol.Optional(CONF_SELECTED_STATION)] = vol.In(station_options)
+
+        # Add other configuration options
+        schema_dict.update({
+            vol.Optional(CONF_DEPARTURES, default=self._user_input.get(CONF_DEPARTURES, DEFAULT_DEPARTURES)): vol.All(int, vol.Range(min=1, max=20)),
+            vol.Optional(CONF_TRANSPORTATION_TYPES, default=self._user_input.get(CONF_TRANSPORTATION_TYPES, list(TRANSPORTATION_TYPES.keys()))): cv.multi_select(list(TRANSPORTATION_TYPES.keys())),
+            vol.Optional(CONF_SCAN_INTERVAL, default=self._user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)): vol.All(int, vol.Range(min=10, max=3600)),
+        })
+
+        schema = vol.Schema(schema_dict)
+
+        description_placeholders = {
+            "search_results": f"Found {len(self._station_suggestions)} stations" if self._station_suggestions else "Enter search term to find stations"
+        }
+
+        return self.async_show_form(
+            step_id="station_search",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders=description_placeholders
+        )
+
+    async def _update_station_suggestions(self, search_term: str):
+        """Update station suggestions based on search term."""
+        if not self._autocomplete:
+            self._autocomplete = StationAutocomplete(self.hass)
+
+        try:
+            self._station_suggestions = await self._autocomplete.search_stations(
+                self._provider, search_term
+            )
+            _LOGGER.debug("Found %d station suggestions for '%s'",
+                          len(self._station_suggestions), search_term)
+        except Exception as e:
+            _LOGGER.error("Error getting station suggestions: %s", e)
+            self._station_suggestions = []
+
+    async def _create_entry_from_selection(self, selected_station: str) -> FlowResult:
+        """Create config entry from selected station."""
+        try:
+            # Parse the selected station key: "place|name|id"
+            parts = selected_station.split("|")
+            if len(parts) != 3:
+                raise ValueError("Invalid station selection format")
+
+            place, name, station_id = parts
+
+            # Create entry data
+            entry_data = {
+                CONF_PROVIDER: self._provider,
+                "place_dm": place,
+                "name_dm": name,
+                CONF_STATION_ID: station_id if station_id != "None" else None,
+                CONF_DEPARTURES: self._user_input.get(CONF_DEPARTURES, DEFAULT_DEPARTURES),
+                CONF_TRANSPORTATION_TYPES: self._user_input.get(CONF_TRANSPORTATION_TYPES, list(TRANSPORTATION_TYPES.keys())),
+                CONF_SCAN_INTERVAL: self._user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            }
+
+            # Create unique ID and title
+            if station_id and station_id != "None":
+                unique_id = f"{self._provider}_{station_id}"
+                title = f"{self._provider.upper()} Station {station_id}"
+            else:
+                unique_id = f"{self._provider}_{place}_{name}".lower().replace(" ", "_")
+                title = f"{self._provider.upper()} {place} - {name}"
+
+            await self.async_set_unique_id(unique_id)
+            self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(title=title, data=entry_data)
+
+        except Exception as e:
+            _LOGGER.error("Error creating entry from selection: %s", e)
+            return self.async_show_form(
+                step_id="station_search",
+                errors={"base": "invalid_selection"}
+            )
+
+    async def _create_entry_from_manual_input(self, user_input: Dict[str, Any]) -> FlowResult:
+        """Create config entry from manual input."""
+        provider = user_input.get(CONF_PROVIDER, "vrr")
+        station_id = user_input.get(CONF_STATION_ID, "").strip()
+        place_dm = user_input.get("place_dm", "").strip()
+        name_dm = user_input.get("name_dm", "").strip()
+
+        # Create unique ID and title
+        if station_id:
+            unique_id = f"{provider}_{station_id}"
+            title = f"{provider.upper()} Station {station_id}"
+        else:
+            unique_id = f"{provider}_{place_dm}_{name_dm}".lower().replace(" ", "_")
+            title = f"{provider.upper()} {place_dm} - {name_dm}"
+
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(title=title, data=user_input)
 
     @staticmethod
     @callback

--- a/custom_components/vrr/const.py
+++ b/custom_components/vrr/const.py
@@ -5,7 +5,7 @@ DEFAULT_DEPARTURES = 10
 DEFAULT_SCAN_INTERVAL = 60
 
 # Configuration keys
-CONF_PROVIDER = "provider"  # NEU
+CONF_PROVIDER = "provider"
 CONF_STATION_ID = "station_id"
 CONF_DEPARTURES = "departures"
 CONF_TRANSPORTATION_TYPES = "transportation_types"
@@ -19,7 +19,7 @@ PROVIDERS = [PROVIDER_VRR, PROVIDER_KVV]
 # Transportation types mapping
 TRANSPORTATION_TYPES = {
     "bus": "Bus",
-    "tram": "Tram", 
+    "tram": "Tram",
     "subway": "U-Bahn",
     "train": "S-Bahn/Train"
 }
@@ -30,9 +30,21 @@ API_RATE_LIMIT_PER_HOUR = 1000
 API_RATE_LIMIT_PER_DAY = 60000
 API_BASE_URL_VRR = "https://openservice-test.vrr.de/static03/XML_DM_REQUEST"
 API_BASE_URL_KVV = "https://projekte.kvv-efa.de/sl3-alone/XSLT_DM_REQUEST"
+
+# NEW: Autocomplete API Configuration
+API_STOPFINDER_URL_VRR = "https://openservice-test.vrr.de/static03/XML_STOPFINDER_REQUEST"
+API_STOPFINDER_URL_KVV = "https://projekte.kvv-efa.de/sl3-alone/XSLT_STOPFINDER_REQUEST"
+
 # Mapping für KVV
 KVV_TRANSPORTATION_TYPES = {
     1: "train",   # S-Bahn
     4: "tram",    # Straßenbahn
     5: "bus",     # Bus
 }
+
+# NEW: Autocomplete Configuration
+CONF_SEARCH_TERM = "search_term"
+CONF_SELECTED_STATION = "selected_station"
+MIN_SEARCH_LENGTH = 3
+MAX_SUGGESTIONS = 10
+AUTOCOMPLETE_TIMEOUT = 5

--- a/custom_components/vrr/strings.json
+++ b/custom_components/vrr/strings.json
@@ -2,31 +2,58 @@
   "config": {
     "step": {
       "user": {
-        "title": "VRR/KVV Departure Configuration",
-        "description": "Configure your VRR or KVV departure sensor",
+        "title": "VRR/KVV Departures Setup",
+        "description": "Configure your transit station. You can either search for stations or enter details manually.",
         "data": {
-          "provider": "Provider (VRR or KVV)",
+          "provider": "Transit Provider",
+          "search_term": "Search for station (3+ characters)",
           "station_id": "Station ID (optional)",
-          "place_dm": "Place/City",
-          "name_dm": "Station Name", 
+          "place_dm": "City/Place",
+          "name_dm": "Station Name",
           "departures": "Number of departures",
-          "scan_interval": "Update interval (seconds)",
-          "transportation_types": "Transportation types"
+          "transportation_types": "Transportation Types",
+          "scan_interval": "Update interval (seconds)"
+        },
+        "data_description": {
+          "search_term": "{search_help}",
+          "station_id": "{station_id_help}",
+          "place_dm": "{place_help}",
+          "name_dm": "{name_help}"
+        }
+      },
+      "station_search": {
+        "title": "Select Station",
+        "description": "Choose from the found stations or refine your search.",
+        "data": {
+          "provider": "Transit Provider",
+          "search_term": "Search term",
+          "selected_station": "Select Station",
+          "departures": "Number of departures",
+          "transportation_types": "Transportation Types",
+          "scan_interval": "Update interval (seconds)"
+        },
+        "data_description": {
+          "selected_station": "{search_results}"
         }
       }
     },
     "error": {
-      "missing_location": "Please provide either a Station ID OR both Place and Station Name"
+      "missing_location": "Please provide either a Station ID or both City and Station Name",
+      "invalid_selection": "Invalid station selection. Please try again.",
+      "search_failed": "Failed to search for stations. Please try manual configuration."
+    },
+    "abort": {
+      "already_configured": "This station is already configured"
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "VRR/KVV Departure Options",
+        "title": "VRR/KVV Options",
         "data": {
           "departures": "Number of departures",
           "scan_interval": "Update interval (seconds)",
-          "transportation_types": "Transportation types"
+          "transportation_types": "Transportation Types"
         }
       }
     }


### PR DESCRIPTION

This pull request introduces a station autocomplete feature for the VRR/KVV transit integration in Home Assistant. The changes include a new class for handling autocomplete functionality, updates to the configuration flow to integrate station search and selection, and enhancements to constants and user-facing strings to support the new feature.

### Autocomplete Functionality:
* Added `StationAutocomplete` class in `custom_components/vrr/autocomplete.py` to handle station search requests for VRR and KVV providers, including methods for making API calls, parsing responses, and extracting station information.

### Configuration Flow Updates:
* Enhanced `custom_components/vrr/config_flow.py` to include station search functionality using autocomplete. Added new steps (`async_step_station_search`) for dynamic station suggestions based on user input. [[1]](diffhunk://#diff-2f2ca540abe840cb1ca43d41f7562a924097377cee3d695428bca5fd9c8c4b9cR2-R75) [[2]](diffhunk://#diff-2f2ca540abe840cb1ca43d41f7562a924097377cee3d695428bca5fd9c8c4b9cL71-R230)

### Constants for Autocomplete:
* Updated `custom_components/vrr/const.py` with new constants for autocomplete API URLs, configuration keys, and limits (e.g., `CONF_SEARCH_TERM`, `MIN_SEARCH_LENGTH`, `MAX_SUGGESTIONS`).

### User Interface Improvements:
* Updated `custom_components/vrr/strings.json` to include new strings for station search, selection, and error handling, enhancing the user experience for the autocomplete feature.